### PR TITLE
chore: Delete .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-*.nr linguist-language=Rust


### PR DESCRIPTION
Github now recognises and syntax highlights Noir code automatically so this file can be removed. This also has the benefit of this repo showing up as Noir rather than Rust!