### PR TITLE
chore(ci): add a CI setup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,64 @@
+name: Noir tests
+
+on:
+  push:
+   branches:
+    - main
+  pull_request:
+
+jobs:
+  test:
+    name: Test on Nargo ${{matrix.toolchain}}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        toolchain: [nightly, 0.35.0]
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Install Nargo
+        uses: noir-lang/noirup@v0.1.3
+        with:
+          toolchain: ${{ matrix.toolchain }}
+
+      - name: Run Noir tests
+        run: nargo test
+
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Install Nargo
+        uses: noir-lang/noirup@v0.1.3
+        with:
+          toolchain: 0.35.0
+
+      - name: Run formatter
+        run: nargo fmt --check
+
+  # This is a job which depends on all test jobs and reports the overall status.
+  # This allows us to add/remove test jobs without having to update the required workflows.
+  tests-end:
+    name: Noir End
+    runs-on: ubuntu-latest
+    # We want this job to always run (even if the dependant jobs fail) as we want this job to fail rather than skipping.
+    if: ${{ always() }}
+    needs: 
+      - test
+      - format
+
+    steps:
+      - name: Report overall success
+        run: |
+          if [[ $FAIL == true ]]; then
+              exit 1
+          else
+              exit 0
+          fi
+        env:
+          # We treat any cancelled, skipped or failing jobs as a failure for the workflow as a whole.
+          FAIL: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        toolchain: [nightly, 0.35.0]
+        toolchain: [nightly, 0.36.0]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4

--- a/lib/src/dkim.nr
+++ b/lib/src/dkim.nr
@@ -1,6 +1,6 @@
-use dep::std::{collections::bounded_vec::BoundedVec, hash::{sha256_var, pedersen_hash}, panic::panic};
-use dep::rsa::{bignum::{fields::{Params1024, Params2048}, runtime_bignum::BigNumInstance, BigNum}, types::RSA};
-use crate::{KEY_LIMBS_1024, KEY_BYTES_1024, KEY_LIMBS_2048, KEY_BYTES_2048, RSA_EXPONENT};
+use crate::{KEY_BYTES_1024, KEY_BYTES_2048, KEY_LIMBS_1024, KEY_LIMBS_2048, RSA_EXPONENT};
+use dep::rsa::{bignum::{BigNum, fields::{Params1024, Params2048}, runtime_bignum::BigNumInstance}, types::RSA};
+use dep::std::{collections::bounded_vec::BoundedVec, hash::{pedersen_hash, sha256_var}};
 
 type BN1024 = BigNum<KEY_LIMBS_1024, Params1024>;
 type RSA1024 = RSA<BN1024, BigNumInstance<KEY_LIMBS_1024, Params1024>, KEY_BYTES_1024>;

--- a/lib/src/headers/mod.nr
+++ b/lib/src/headers/mod.nr
@@ -1,9 +1,7 @@
-use crate::{Sequence, CR, LF};
+use crate::{CR, LF, Sequence};
 
 pub mod body_hash;
 pub mod email_address;
-
-
 
 /**
  * Constrain a sequence in a header to match the specific header field
@@ -18,16 +16,15 @@ pub mod email_address;
 pub fn constrain_header_field<
     let MAX_HEADER_LENGTH: u32,
     let MAX_HEADER_FIELD_LENGTH: u32,
-    let HEADER_FIELD_NAME_LENGTH: u32,
+    let HEADER_FIELD_NAME_LENGTH: u32
 >(
     header: BoundedVec<u8, MAX_HEADER_LENGTH>,
     header_field_sequence: Sequence,
-    header_field_name: [u8; HEADER_FIELD_NAME_LENGTH],
+    header_field_name: [u8; HEADER_FIELD_NAME_LENGTH]
 ) {
     // check that the sequence is within bounds
     assert(
-        header_field_sequence.index + header_field_sequence.length <= header.len(),
-        "Header field out of bounds"
+        header_field_sequence.index + header_field_sequence.length <= header.len(), "Header field out of bounds"
     );
     // check the range of the sequence is within the header (so we can use get_unchecked)
     let end_index = header_field_sequence.index + header_field_sequence.length;
@@ -35,29 +32,26 @@ pub fn constrain_header_field<
 
     // if the sequence is not the start, check for a newline
     if header_field_sequence.index != 0 {
-        assert(header.get_unchecked(header_field_sequence.index - 2) == CR, "Header field must start with CRLF");
-        assert(header.get_unchecked(header_field_sequence.index - 1) == LF, "Header field must start with CRLF");
+        assert(
+            header.get_unchecked(header_field_sequence.index - 2) == CR, "Header field must start with CRLF"
+        );
+        assert(
+            header.get_unchecked(header_field_sequence.index - 1) == LF, "Header field must start with CRLF"
+        );
     }
     // if the sequence is not the end, check for a newline
     if end_index != header.len() {
-        assert(
-            header.get_unchecked(end_index) == CR,
-            "Header field must end with CRLF"
-        );
-        assert(header.get_unchecked(end_index + 1) == LF,
-        "Header field must end with CRLF"
-        );
+        assert(header.get_unchecked(end_index) == CR, "Header field must end with CRLF");
+        assert(header.get_unchecked(end_index + 1) == LF, "Header field must end with CRLF");
     }
     // check that the header field name matches the expected name
     for i in 0..HEADER_FIELD_NAME_LENGTH {
         assert(
-            header.get_unchecked(header_field_sequence.index + i) == header_field_name[i],
-            "Header field name does not match"
+            header.get_unchecked(header_field_sequence.index + i) == header_field_name[i], "Header field name does not match"
         );
     }
     assert(
-        header.get_unchecked(header_field_sequence.index + HEADER_FIELD_NAME_LENGTH) == 0x3a,
-        "Header field name must be followed by a colon"
+        header.get_unchecked(header_field_sequence.index + HEADER_FIELD_NAME_LENGTH) == 0x3a, "Header field name must be followed by a colon"
     );
     // check the header field is uninterrupted
     let start_index = header_field_sequence.index + HEADER_FIELD_NAME_LENGTH + 1;
@@ -65,10 +59,7 @@ pub fn constrain_header_field<
         // is it safe enough to cut this constraint cost in half by not checking lf? i think so
         let index = start_index + i;
         if (index < header_field_sequence.index + header_field_sequence.length) {
-            assert(
-                header.get_unchecked(index) != CR,
-                "Header field must not contain newlines"
-            );
+            assert(header.get_unchecked(index) != CR, "Header field must not contain newlines");
         }
     }
 }
@@ -79,16 +70,15 @@ pub fn constrain_header_field<
 pub fn constrain_header_field_detect_last_angle_bracket<
     let MAX_HEADER_LENGTH: u32,
     let MAX_HEADER_FIELD_LENGTH: u32,
-    let HEADER_FIELD_NAME_LENGTH: u32,
+    let HEADER_FIELD_NAME_LENGTH: u32
 >(
     header: BoundedVec<u8, MAX_HEADER_LENGTH>,
     header_field_sequence: Sequence,
-    header_field_name: [u8; HEADER_FIELD_NAME_LENGTH],
+    header_field_name: [u8; HEADER_FIELD_NAME_LENGTH]
 ) -> u32 {
     // check that the sequence is within bounds
     assert(
-        header_field_sequence.index + header_field_sequence.length <= header.len(),
-        "Header field out of bounds"
+        header_field_sequence.index + header_field_sequence.length <= header.len(), "Header field out of bounds"
     );
     // check the range of the sequence is within the header (so we can use get_unchecked)
     let end_index = header_field_sequence.index + header_field_sequence.length;
@@ -96,29 +86,26 @@ pub fn constrain_header_field_detect_last_angle_bracket<
 
     // if the sequence is not the start, check for a newline
     if header_field_sequence.index != 0 {
-        assert(header.get_unchecked(header_field_sequence.index - 2) == CR, "Header field must start with CRLF");
-        assert(header.get_unchecked(header_field_sequence.index - 1) == LF, "Header field must start with CRLF");
+        assert(
+            header.get_unchecked(header_field_sequence.index - 2) == CR, "Header field must start with CRLF"
+        );
+        assert(
+            header.get_unchecked(header_field_sequence.index - 1) == LF, "Header field must start with CRLF"
+        );
     }
     // if the sequence is not the end, check for a newline
     if end_index != header.len() {
-        assert(
-            header.get_unchecked(end_index) == CR,
-            "Header field must end with CRLF"
-        );
-        assert(header.get_unchecked(end_index + 1) == LF,
-            "Header field must end with CRLF"
-        );
+        assert(header.get_unchecked(end_index) == CR, "Header field must end with CRLF");
+        assert(header.get_unchecked(end_index + 1) == LF, "Header field must end with CRLF");
     }
     // check that the header field name matches the expected name
     for i in 0..HEADER_FIELD_NAME_LENGTH {
         assert(
-            header.get_unchecked(header_field_sequence.index + i) == header_field_name[i],
-            "Header field name does not match"
+            header.get_unchecked(header_field_sequence.index + i) == header_field_name[i], "Header field name does not match"
         );
     }
     assert(
-        header.get_unchecked(header_field_sequence.index + HEADER_FIELD_NAME_LENGTH) == 0x3a,
-        "Header field name must be followed by a colon"
+        header.get_unchecked(header_field_sequence.index + HEADER_FIELD_NAME_LENGTH) == 0x3a, "Header field name must be followed by a colon"
     );
     // check the header field is uninterrupted
     let mut last_angle_bracket = 0;
@@ -128,10 +115,7 @@ pub fn constrain_header_field_detect_last_angle_bracket<
         let index = start_index + i;
         if (index < header_field_sequence.index + header_field_sequence.length) {
             let byte = header.get_unchecked(index);
-            assert(
-                byte != CR,
-                "Header field must not contain newlines"
-            );
+            assert(byte != CR, "Header field must not contain newlines");
             if byte == 0x3c {
                 last_angle_bracket = index;
             }

--- a/lib/src/macro.nr
+++ b/lib/src/macro.nr
@@ -1,7 +1,5 @@
 use dep::std::{
-    meta::unquote,
-    collections::umap::UHashMap,
-    hash::{BuildHasherDefault, poseidon2::Poseidon2Hasher},
+    meta::unquote, collections::umap::UHashMap, hash::{BuildHasherDefault, poseidon2::Poseidon2Hasher},
     option::Option
 };
 
@@ -26,8 +24,6 @@ comptime mut global USED: UHashMap<Field, bool, BuildHasherDefault<Poseidon2Hash
 comptime fn zkemail(s: StructDefinition) -> Quoted {
     // setup the dkim check
     derive_dkim_check(s)
-
-
     // // check the 
     // let should_check_body = s.has_named_attribute("check_body");
     // let should_partial_hash = s.has_named_attribute("partial_hash");
@@ -39,11 +35,10 @@ comptime fn zkemail(s: StructDefinition) -> Quoted {
     //     // check it does not also have the check_body attribute
     //     let _ = s.add_generic("let MAX_EMAIL_BODY_LENGTH: u32");
     // }
-
     // no matter what, add verify signature
     // derive_dkim_check(s)
     // quote {}
-}   
+}
 
 comptime fn derive_dkim_check(s: StructDefinition) -> Quoted {
     // figure out key byte length
@@ -132,7 +127,7 @@ pub fn test_fn() {
     let header: BoundedVec<u8, HEADER_LEN> = BoundedVec::new();
     let signature: [Field; KEY_LIMBS_2048] = [0; KEY_LIMBS_2048];
     let pubkey = RSAPubkey::<KEY_LIMBS_2048> { modulus: [0; KEY_LIMBS_2048], redc: [0; KEY_LIMBS_2048] };
-    let i: input<HEADER_LEN, KEY_LIMBS_2048> = input{ header, pubkey, signature };
+    let i: input<HEADER_LEN, KEY_LIMBS_2048> = input { header, pubkey, signature };
     i.verify_dkim_signature();
     // i.do_nothing();
 }
@@ -154,7 +149,6 @@ pub fn test_fn() {
 //         // }
 //         quote {}
 //     }
-
 
 // impl<MAX_EMAIL_HEADER_LENGTH, KEY_LIMBS> for input where MAX_EMAIL_HEADER_LENGTH: u32, KEY_LIMBS: u32 {
 //     fn check_body(self) {

--- a/lib/src/masking.nr
+++ b/lib/src/masking.nr
@@ -9,10 +9,7 @@ use dep::std::collections::bounded_vec::BoundedVec;
  * @param mask - The mask to apply to the text
  * @return - The masked text
  */
-pub fn mask_text<let TEXT_LEN: u32>(
-    text: BoundedVec<u8, TEXT_LEN>,
-    mask: [bool; TEXT_LEN],
-) -> [u8; TEXT_LEN] {
+pub fn mask_text<let TEXT_LEN: u32>(text: BoundedVec<u8, TEXT_LEN>, mask: [bool; TEXT_LEN]) -> [u8; TEXT_LEN] {
     let mut masked_text = [0; TEXT_LEN];
     // probably fine to just iterate through whole thing without an if statement
     for i in 0..TEXT_LEN {

--- a/lib/src/partial_hash.nr
+++ b/lib/src/partial_hash.nr
@@ -147,7 +147,7 @@ pub fn partial_sha256_var_interstitial<let N: u32>(mut h: [u32; 8], msg: [u8; N]
 
         // If the block is filled, compress it.
         // An un-filled block is handled after this loop.
-        if (msg_start < N) & (msg_byte_ptr == BLOCK_SIZE) & (msg_start < message_size){
+        if (msg_start < N) & (msg_byte_ptr == BLOCK_SIZE) & (msg_start < message_size) {
             h = sha256_compression(msg_u8_to_u32(msg_block), h);
         }
     }

--- a/lib/src/remove_soft_line_breaks.nr
+++ b/lib/src/remove_soft_line_breaks.nr
@@ -113,11 +113,11 @@ pub fn remove_soft_line_breaks<let N: u32>(encoded: [u8; N], decoded: [u8; N]) -
 pub fn test_remove_soft_line_breaks() {
     let encoded = [
         115, 101, 115, 58, 61, 13, 10, 45, 32, 83, 114, 101, 97, 107, 61, 13, 10, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0
     ];
     let decoded = [
         115, 101, 115, 58, 45, 32, 83, 114, 101, 97, 107, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0
     ];
     let res = remove_soft_line_breaks(encoded, decoded);
     assert(res, "Expected to remove soft line breaks");
@@ -127,11 +127,11 @@ pub fn test_remove_soft_line_breaks() {
 pub fn test_return_false_incorrect_decoded_input() {
     let encoded = [
         115, 101, 115, 58, 61, 13, 10, 45, 32, 83, 114, 101, 97, 107, 61, 13, 10, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0
     ];
     let decoded = [
         115, 101, 115, 58, 45, 32, 83, 114, 101, 97, 108, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0
     ];
     let res = remove_soft_line_breaks(encoded, decoded);
     assert(!res, "Expected to return false for incorrect decoded input");
@@ -141,11 +141,11 @@ pub fn test_return_false_incorrect_decoded_input() {
 pub fn test_handle_no_soft_line_breaks() {
     let encoded = [
         104, 101, 108, 108, 111, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0
     ];
     let decoded = [
         104, 101, 108, 108, 111, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0
     ];
     let res = remove_soft_line_breaks(encoded, decoded);
     assert(res, "Expected to handle no soft line breaks");
@@ -155,11 +155,11 @@ pub fn test_handle_no_soft_line_breaks() {
 pub fn test_handle_consecutive_soft_line_breaks() {
     let encoded = [
         104, 101, 108, 108, 111, 61, 13, 10, 61, 13, 10, 119, 111, 114, 108, 100, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0
     ];
     let decoded = [
         104, 101, 108, 108, 111, 119, 111, 114, 108, 100, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0
     ];
     let res = remove_soft_line_breaks(encoded, decoded);
     assert(res, "Expected to handle consecutive soft line breaks");
@@ -169,11 +169,11 @@ pub fn test_handle_consecutive_soft_line_breaks() {
 pub fn test_handle_soft_line_break_beginning() {
     let encoded = [
         61, 13, 10, 104, 101, 108, 108, 111, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0
     ];
     let decoded = [
         104, 101, 108, 108, 111, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0
     ];
     let res = remove_soft_line_breaks(encoded, decoded);
     assert(res, "Expected to handle soft line break at beginning");
@@ -183,11 +183,11 @@ pub fn test_handle_soft_line_break_beginning() {
 pub fn test_handle_soft_line_break_end() {
     let encoded = [
         104, 101, 108, 108, 111, 61, 13, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0
     ];
     let decoded = [
         104, 101, 108, 108, 111, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0
     ];
     let res = remove_soft_line_breaks(encoded, decoded);
     assert(res, "Expected to handle soft line break at end");
@@ -197,11 +197,11 @@ pub fn test_handle_soft_line_break_end() {
 pub fn test_handle_incomplete_line_break() {
     let encoded = [
         104, 101, 108, 108, 111, 61, 13, 11, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0
     ];
     let decoded = [
         104, 101, 108, 108, 111, 61, 13, 11, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0
     ];
     let res = remove_soft_line_breaks(encoded, decoded);
     assert(res, "Expected to handle incomplete line break");

--- a/lib/src/tests/mod.nr
+++ b/lib/src/tests/mod.nr
@@ -3,8 +3,8 @@ mod test_inputs;
 mod test_success {
 
     use crate::{
-        headers::{email_address::get_email_address, body_hash::get_body_hash},
-        tests::test_inputs::EmailLarge, partial_hash::partial_sha256_var_end, MAX_EMAIL_ADDRESS_LENGTH
+        headers::{body_hash::get_body_hash, email_address::get_email_address}, MAX_EMAIL_ADDRESS_LENGTH,
+        partial_hash::partial_sha256_var_end, tests::test_inputs::EmailLarge
     };
     use std::hash::sha256_var;
 
@@ -150,7 +150,7 @@ mod header_field_access {
             dkim_field.storage[index] = malicious_to[i];
         }
         let malicious_body_hash_index = 15;
-        // copy the body hash to the beginning of the 
+        // copy the body hash to the beginning of the
         // attempt to get body hash
         let _ = get_body_hash(dkim_field, malicious_sequence, malicious_body_hash_index);
     }
@@ -221,14 +221,16 @@ mod header_field_access {
         tampered_header.len = combined_sequence.length + 4;
         // copy dkim-signature field
         for i in 0..EmailLarge::DKIM_HEADER_SEQUENCE.length + 2 {
-            tampered_header.storage[i] = EmailLarge::HEADER.storage[EmailLarge::DKIM_HEADER_SEQUENCE.index + i - 2];
+            tampered_header.storage[i] =
+                EmailLarge::HEADER.storage[EmailLarge::DKIM_HEADER_SEQUENCE.index + i - 2];
         }
         tampered_header.storage[EmailLarge::DKIM_HEADER_SEQUENCE.length + 2] = "\r".as_bytes()[0];
         tampered_header.storage[EmailLarge::DKIM_HEADER_SEQUENCE.length + 3] = "\n".as_bytes()[0];
         // copy to field
         for i in 0..EmailLarge::TO_HEADER_SEQUENCE.length + 2 {
             let index = EmailLarge::DKIM_HEADER_SEQUENCE.length + 4;
-            tampered_header.storage[index + i] = EmailLarge::HEADER.storage[EmailLarge::TO_HEADER_SEQUENCE.index + i];
+            tampered_header.storage[index + i] =
+                EmailLarge::HEADER.storage[EmailLarge::TO_HEADER_SEQUENCE.index + i];
         }
         // set crlf at end
         tampered_header.storage[combined_sequence.length + 2] = "\r".as_bytes()[0];
@@ -242,7 +244,8 @@ mod header_field_access {
     fn test_header_field_outside_header() {
         let mut shortened_header = EmailLarge::HEADER;
         // shorten header to be just under the end of the dkim field
-        shortened_header.len = EmailLarge::DKIM_HEADER_SEQUENCE.index + EmailLarge::DKIM_HEADER_SEQUENCE.length - 1;
+        shortened_header.len =
+            EmailLarge::DKIM_HEADER_SEQUENCE.index + EmailLarge::DKIM_HEADER_SEQUENCE.length - 1;
         // attempt to get body hash
         let _ = get_body_hash(
             shortened_header,
@@ -254,7 +257,7 @@ mod header_field_access {
 
 mod test_address_extraction {
     // header field constrains are not checked here, should work same as tests in header_field_access
-    use crate::{headers::email_address::get_email_address, Sequence, tests::test_inputs::EmailAddresses};
+    use crate::{headers::email_address::get_email_address, tests::test_inputs::EmailAddresses};
 
     #[test]
     fn test_email_only() {

--- a/lib/src/tests/test_inputs.nr
+++ b/lib/src/tests/test_inputs.nr
@@ -71,7 +71,7 @@ mod EmailLarge {
 }
 
 mod EmailAddresses {
-    
+
     use crate::{Sequence, MAX_EMAIL_ADDRESS_LENGTH};
     global ADDRESS: BoundedVec<u8, MAX_EMAIL_ADDRESS_LENGTH> = BoundedVec::from_array("runnier.leagues.0j@icloud.com".as_bytes());
     global ADDRESS_ONLY: [u8; 38] = comptime { "\r\nfrom:runnier.leagues.0j@icloud.com\r\n".as_bytes() };


### PR DESCRIPTION
This PR adds some simple CI to check that tests pass on noir 0.35.0 and the latest nightly release (nightly is going to be failing until #20 is merged due to breaking changes).

This also enforces that the code is formatted with `nargo fmt`, I've added the necessary changes to this PR to get the code matching the formatter.