### PR TITLE
Update dependencies for Noir nightly - 1.0.0-beta.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        toolchain: [1.0.0-beta.1]
+        toolchain: [1.0.0-beta.4]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -36,7 +36,7 @@ jobs:
       - name: Install Nargo
         uses: noir-lang/noirup@v0.1.3
         with:
-          toolchain: 1.0.0-beta.1
+          toolchain: 1.0.0-beta.4
 
       - name: Run formatter
         working-directory: ./lib

--- a/examples/email_mask/Nargo.toml
+++ b/examples/email_mask/Nargo.toml
@@ -5,4 +5,5 @@ authors = ["Mach 34"]
 compiler_version = ">=1.0.0"
 
 [dependencies]
-zkemail = { path =  "../../lib"}
+zkemail = { path = "../../lib" }
+sha256 = { git = "https://github.com/noir-lang/sha256", tag = "v0.1.2" }

--- a/examples/email_mask/src/main.nr
+++ b/examples/email_mask/src/main.nr
@@ -1,4 +1,5 @@
-use std::{collections::bounded_vec::BoundedVec, hash::{pedersen_hash, sha256_var}};
+use sha256::sha256_var;
+use std::{collections::bounded_vec::BoundedVec, hash::pedersen_hash};
 use zkemail::{
     dkim::RSAPubkey, headers::body_hash::get_body_hash, KEY_LIMBS_2048, masking::mask_text,
     Sequence,

--- a/examples/remove_soft_line_breaks/Nargo.toml
+++ b/examples/remove_soft_line_breaks/Nargo.toml
@@ -5,4 +5,5 @@ authors = ["Mach 34"]
 compiler_version = ">=1.0.0"
 
 [dependencies]
-zkemail = { path =  "../../lib"}
+zkemail = { path = "../../lib" }
+sha256 = { git = "https://github.com/noir-lang/sha256", tag = "v0.1.2" }

--- a/examples/remove_soft_line_breaks/src/main.nr
+++ b/examples/remove_soft_line_breaks/src/main.nr
@@ -1,4 +1,5 @@
-use std::hash::{pedersen_hash, sha256_var};
+use sha256::sha256_var;
+use std::hash::pedersen_hash;
 use zkemail::{
     dkim::RSAPubkey, headers::body_hash::get_body_hash, KEY_LIMBS_2048,
     remove_soft_line_breaks::remove_soft_line_breaks, Sequence,

--- a/examples/verify_email_1024_bit_dkim/Nargo.toml
+++ b/examples/verify_email_1024_bit_dkim/Nargo.toml
@@ -5,4 +5,5 @@ authors = ["Mach 34"]
 compiler_version = ">=1.0.0"
 
 [dependencies]
-zkemail = { path =  "../../lib"}
+zkemail = { path = "../../lib" }
+sha256 = { git = "https://github.com/noir-lang/sha256", tag = "v0.1.2" }

--- a/examples/verify_email_1024_bit_dkim/src/main.nr
+++ b/examples/verify_email_1024_bit_dkim/src/main.nr
@@ -1,4 +1,5 @@
-use std::{collections::bounded_vec::BoundedVec, hash::{pedersen_hash, sha256_var}};
+use sha256::sha256_var;
+use std::{collections::bounded_vec::BoundedVec, hash::pedersen_hash};
 use zkemail::{dkim::RSAPubkey, headers::body_hash::get_body_hash, KEY_LIMBS_1024, Sequence};
 
 global MAX_EMAIL_HEADER_LENGTH: u32 = 512;

--- a/examples/verify_email_2048_bit_dkim/Nargo.toml
+++ b/examples/verify_email_2048_bit_dkim/Nargo.toml
@@ -6,3 +6,4 @@ compiler_version = ">=1.0.0"
 
 [dependencies]
 zkemail = { path =  "../../lib"}
+sha256 = { git = "https://github.com/noir-lang/sha256", tag = "v0.1.2" }

--- a/examples/verify_email_2048_bit_dkim/src/main.nr
+++ b/examples/verify_email_2048_bit_dkim/src/main.nr
@@ -1,4 +1,5 @@
-use std::{collections::bounded_vec::BoundedVec, hash::{pedersen_hash, sha256_var}};
+use sha256::sha256_var;
+use std::{collections::bounded_vec::BoundedVec, hash::pedersen_hash};
 use zkemail::{dkim::RSAPubkey, headers::body_hash::get_body_hash, KEY_LIMBS_2048, Sequence};
 
 global MAX_EMAIL_HEADER_LENGTH: u32 = 512;

--- a/lib/Nargo.toml
+++ b/lib/Nargo.toml
@@ -8,5 +8,5 @@ compiler_version = ">=1.0.0"
 bignum = { tag = "v0.6.0", git = "https://github.com/noir-lang/noir-bignum" }
 rsa = { tag = "v0.7.0", git = "https://github.com/noir-lang/noir_rsa" }
 base64 = { tag = "v0.4.0", git = "https://github.com/noir-lang/noir_base64" }
-nodash = { tag = "v0.41.0", git = "https://github.com/olehmisar/nodash" }
+nodash = { tag = "v0.40.2", git = "https://github.com/olehmisar/nodash" }
 sha256 = { git = "https://github.com/noir-lang/sha256", tag = "v0.1.2" }

--- a/lib/Nargo.toml
+++ b/lib/Nargo.toml
@@ -5,7 +5,8 @@ authors = ["Mach 34"]
 compiler_version = ">=1.0.0"
 
 [dependencies]
-bignum = { tag = "v0.5.2", git = "https://github.com/noir-lang/noir-bignum" }
-rsa = { tag = "v0.5.1", git = "https://github.com/noir-lang/noir_rsa", directory = "lib" }
-base64 = { tag = "v0.3.1", git = "https://github.com/noir-lang/noir_base64" }
-nodash = { tag = "v0.39.4", git = "https://github.com/olehmisar/nodash" }
+bignum = { tag = "v0.6.0", git = "https://github.com/noir-lang/noir-bignum" }
+rsa = { tag = "v0.7.0", git = "https://github.com/noir-lang/noir_rsa" }
+base64 = { tag = "v0.4.0", git = "https://github.com/noir-lang/noir_base64" }
+nodash = { tag = "v0.41.0", git = "https://github.com/olehmisar/nodash" }
+sha256 = { git = "https://github.com/noir-lang/sha256", tag = "v0.1.2" }

--- a/lib/src/dkim.nr
+++ b/lib/src/dkim.nr
@@ -1,7 +1,8 @@
 use crate::{KEY_LIMBS_1024, KEY_LIMBS_2048, RSA_EXPONENT};
 use bignum::{params::BigNumParams, RuntimeBigNum};
 use rsa::{rsa::verify_sha256_pkcs1v15, types::{RBN1024, RBN2048}};
-use std::hash::{pedersen_hash, sha256_var};
+use sha256::sha256_var;
+use std::hash::pedersen_hash;
 
 pub struct RSAPubkey<let KEY_LIMBS: u32> {
     modulus: [Field; KEY_LIMBS],
@@ -25,10 +26,14 @@ impl RSAPubkey<KEY_LIMBS_1024> {
         // hash the header
         let header_hash = sha256_var(header.storage(), header.len() as u64);
 
-        let params: BigNumParams<KEY_LIMBS_1024, 1024> =
-            BigNumParams::new(false, self.modulus, self.redc);
+        let params: BigNumParams<KEY_LIMBS_1024, 1024> = BigNumParams::new(
+            false,
+            convert_field_to_u128(self.modulus),
+            convert_field_to_u128(self.redc),
+        );
 
-        let signature: RBN1024 = RuntimeBigNum::from_array(params, signature);
+        let signature: RBN1024 =
+            RuntimeBigNum::from_array(params, convert_field_to_u128(signature));
         signature.validate_in_range();
 
         // verify the DKIM signature over the header
@@ -72,10 +77,14 @@ impl RSAPubkey<KEY_LIMBS_2048> {
         // hash the header
         let header_hash = sha256_var(header.storage(), header.len() as u64);
 
-        let params: BigNumParams<KEY_LIMBS_2048, 2048> =
-            BigNumParams::new(false, self.modulus, self.redc);
+        let params: BigNumParams<KEY_LIMBS_2048, 2048> = BigNumParams::new(
+            false,
+            convert_field_to_u128(self.modulus),
+            convert_field_to_u128(self.redc),
+        );
 
-        let signature: RBN2048 = RuntimeBigNum::from_array(params, signature);
+        let signature: RBN2048 =
+            RuntimeBigNum::from_array(params, convert_field_to_u128(signature));
         signature.validate_in_range();
 
         // verify the DKIM signature over the header
@@ -105,4 +114,13 @@ impl RSAPubkey<KEY_LIMBS_2048> {
         self.modulus[KEY_LIMBS_2048 - 1].assert_max_bit_size::<2048 - ((KEY_LIMBS_2048 - 1) * 120)>();
         self.redc[KEY_LIMBS_2048 - 1].assert_max_bit_size::<120>(); // we get 2053 sometimes?
     }
+}
+
+// convert a Field array to a u128 array with generic number of limbs
+fn convert_field_to_u128<let KEY_LIMBS: u32>(signature: [Field; KEY_LIMBS]) -> [u128; KEY_LIMBS] {
+    let mut u128_signature: [u128; KEY_LIMBS] = [0; KEY_LIMBS];
+    for i in 0..KEY_LIMBS {
+        u128_signature[i] = signature[i] as u128;
+    }
+    u128_signature
 }

--- a/lib/src/headers/body_hash.nr
+++ b/lib/src/headers/body_hash.nr
@@ -86,5 +86,5 @@ pub fn get_body_hash_unsafe<let MAX_HEADER_LENGTH: u32>(
     }
     // return the decoded body hash
     // idk why encode vs decode...
-    BASE64_DECODER.decode(body_hash_encoded)
+    BASE64_DECODER::decode(body_hash_encoded)
 }

--- a/lib/src/headers/email_address.nr
+++ b/lib/src/headers/email_address.nr
@@ -70,4 +70,3 @@ pub fn parse_email_address<let MAX_HEADER_LENGTH: u32>(
     // todo: should probably introduce a check for @
     email_address
 }
-

--- a/lib/src/partial_hash.nr
+++ b/lib/src/partial_hash.nr
@@ -363,7 +363,7 @@ fn test_partial_hash() {
     }
     let state = partial_sha256_var_start(data0);
     let hash = partial_sha256_var_end(state, data1, data1.len() as u64, DATA.len() as u64);
-    let correct_hash = std::hash::sha256_var(DATA, DATA.len() as u64);
+    let correct_hash = sha256::sha256_var(DATA, DATA.len() as u64);
     assert_eq(hash, correct_hash);
 }
 
@@ -385,7 +385,7 @@ fn test_partial_hash_interstitial() {
         data2.len() as u64,
         DATA.len() as u64,
     );
-    let correct_hash = std::hash::sha256_var(DATA, DATA.len() as u64);
+    let correct_hash = sha256::sha256_var(DATA, DATA.len() as u64);
     assert_eq(hash, correct_hash);
 }
 
@@ -407,6 +407,6 @@ fn test_partial_hash_interstitial_var() {
         data2.len() as u64,
         DATA.len() as u64,
     );
-    let correct_hash = std::hash::sha256_var(DATA, DATA.len() as u64);
+    let correct_hash = sha256::sha256_var(DATA, DATA.len() as u64);
     assert_eq(hash, correct_hash);
 }

--- a/lib/src/tests/mod.nr
+++ b/lib/src/tests/mod.nr
@@ -8,7 +8,7 @@ mod test_success {
         partial_hash::partial_sha256_var_end,
         tests::test_inputs::EmailLarge,
     };
-    use std::hash::sha256_var;
+    use sha256::sha256_var;
 
     #[test]
     fn test_dkim_signature() {
@@ -87,7 +87,7 @@ mod test_success {
 
 mod test_tampered_hash {
     use crate::{headers::body_hash::get_body_hash, tests::test_inputs::EmailLarge};
-    use std::hash::sha256_var;
+    use sha256::sha256_var;
 
     // no reasonable message to constrain here
     #[test(should_fail)]


### PR DESCRIPTION
Extended from #45 since some tweaks required

This is to address [noir-jwt Issue#14](https://github.com/zkemail/noir-jwt/issues/14) where `noir-jwt` fails for Noir `nightly`.

Update dependencies:

- `bignum` to `v0.6.0`
- `rsa` to `v0.7.0`
- `base64` to `v0.4.0`
- `nodash` to `v0.41.0`

Add dependency:
- sha256 `v0.1.2`

---

Tests passed for Noir `nightly`, specifically:

`nargo version = 1.0.0-beta.4`
`noirc version = 1.0.0-beta.4+4c76f4e698c8122c442d02b0086c3c9704af927b`