### PR TITLE
Feat: Update nodash version to v0.41.1

### DIFF
--- a/lib/Nargo.toml
+++ b/lib/Nargo.toml
@@ -8,6 +8,6 @@ compiler_version = ">=1.0.0"
 bignum = { tag = "v0.6.0", git = "https://github.com/noir-lang/noir-bignum" }
 rsa = { tag = "v0.7.0", git = "https://github.com/noir-lang/noir_rsa" }
 base64 = { tag = "v0.4.0", git = "https://github.com/noir-lang/noir_base64" }
-nodash = { tag = "v0.40.2", git = "https://github.com/olehmisar/nodash" }
+nodash = { tag = "v0.41.1", git = "https://github.com/olehmisar/nodash" }
 sha256 = { git = "https://github.com/noir-lang/sha256", tag = "v0.1.2" }
 poseidon = { tag = "v0.1.0", git = "https://github.com/noir-lang/poseidon" }


### PR DESCRIPTION
Update the **nodash** version to `v0.41.1` in order to use the **zkemail.nr** along with the **noir-jwt** `v0.5.0` (under the nargo version = `1.0.0-beta.4`).