### PR TITLE
fix: include redc hash in the output to bind prover to redc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2026-03-02
+
+### Changed
+
+- `RSAPubkey::hash()` now returns `[Field; 2]` — separate Poseidon hashes for modulus and redc parameter
+- `hashRSAPublicKey()` JS function now returns `{ modulusHash, redcHash }` instead of a single `bigint`
+- Example circuit outputs grow from 2 to 3 public fields (`[modulus_hash, redc_hash, email_nullifier]`)
+
+### Added
+
+- `poseidon_large_padded_1024` helper for hashing 1024-bit keys by zero-padding to 2048-bit width
+- 1024-bit key support in JS `hashRSAPublicKey()` (accepts 9-limb arrays)
+- `RSAPublicKeyHashes` type export from JS package
+- Regression tests for redc binding on both 1024-bit and 2048-bit code paths
+
+### Fixed
+
+- Bind prover to redc parameter — previously only the modulus was hashed, allowing a malicious prover to supply an arbitrary redc and still match the public key hash (Veridise vulnerability reintroduced in PR #52)
+
+### Breaking Changes
+
+- **Verifier keys must be regenerated.** The `hash()` return type and circuit outputs have changed.
+- **JS consumers** must update to destructure `{ modulusHash, redcHash }` instead of using a single `bigint` return value.
+
 ## [1.4.0] - 2026-03-02
 
 ### Fixed
@@ -56,6 +80,7 @@ _Released as git tag `v.1.0.0-beta.5`._
 
 - Minor fixes
 
+[2.0.0]: https://github.com/zkemail/zkemail.nr/compare/v1.4.0...v2.0.0
 [1.4.0]: https://github.com/zkemail/zkemail.nr/compare/v.1.0.1-beta.5...v1.4.0
 [1.0.1-beta.5]: https://github.com/zkemail/zkemail.nr/compare/v.1.0.0-beta.5...v.1.0.1-beta.5
 [1.0.0-beta.5]: https://github.com/zkemail/zkemail.nr/compare/v0.4.4...v.1.0.0-beta.5

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ In your Nargo.toml file, add the version of this library you would like to insta
 
 ```toml
 [dependencies]
-zkemail = { tag = "v1.4.0", git = "https://github.com/zkemail/zkemail.nr", directory = "lib" }
+zkemail = { tag = "v2.0.0", git = "https://github.com/zkemail/zkemail.nr", directory = "lib" }
 ```
 
 The library exports the following functions:

--- a/examples/email_mask/src/main.nr
+++ b/examples/email_mask/src/main.nr
@@ -20,8 +20,9 @@ global MAX_EMAIL_BODY_LENGTH: u32 = 1024;
  * @param header_mask - The mask for the header
  * @param body_mask - The mask for the body
  * @return - 
- *         0: Pedersen hash of DKIM public key (root of trust)
- *         1: Pedersen hash of DKIM signature (email nullifier)
+ *         0: Poseidon hash of DKIM public key modulus (root of trust)
+ *         1: Poseidon hash of DKIM public key redc parameter
+ *         2: Pedersen hash of DKIM signature (email nullifier)
  */
 fn main(
     header: BoundedVec<u8, MAX_EMAIL_HEADER_LENGTH>,
@@ -32,7 +33,7 @@ fn main(
     dkim_header_sequence: Sequence,
     header_mask: [bool; MAX_EMAIL_HEADER_LENGTH],
     body_mask: [bool; MAX_EMAIL_BODY_LENGTH],
-) -> pub ([Field; 2], [u8; MAX_EMAIL_HEADER_LENGTH], [u8; MAX_EMAIL_BODY_LENGTH]) {
+) -> pub ([Field; 3], [u8; MAX_EMAIL_HEADER_LENGTH], [u8; MAX_EMAIL_BODY_LENGTH]) {
     // check the body and header lengths are within bounds
     assert(header.len() <= MAX_EMAIL_HEADER_LENGTH);
     assert(body.len() <= MAX_EMAIL_BODY_LENGTH);
@@ -58,6 +59,7 @@ fn main(
 
     // hash the pubkey and signature for the standard outputs
     let email_nullifier = pedersen_hash(signature);
-    let standard_out = [pubkey.hash(), email_nullifier];
+    let pubkey_hash = pubkey.hash();
+    let standard_out = [pubkey_hash[0], pubkey_hash[1], email_nullifier];
     (standard_out, masked_header, masked_body)
 }

--- a/examples/extract_addresses/src/main.nr
+++ b/examples/extract_addresses/src/main.nr
@@ -18,8 +18,9 @@ global MAX_EMAIL_HEADER_LENGTH: u32 = 512;
  * @param to_header_sequence - The index and length of the "To" header field
  * @param to_address_sequence - The index and length of the "To" email address
  * @return - 
- *         0: Pedersen hash of DKIM public key (root of trust)
- *         1: Pedersen hash of DKIM signature (email nullifier)
+ *         0: Poseidon hash of DKIM public key modulus (root of trust)
+ *         1: Poseidon hash of DKIM public key redc parameter
+ *         2: Pedersen hash of DKIM signature (email nullifier)
  */
 fn main(
     header: BoundedVec<u8, MAX_EMAIL_HEADER_LENGTH>,
@@ -29,7 +30,7 @@ fn main(
     from_address_sequence: Sequence,
     to_header_sequence: Sequence,
     to_address_sequence: Sequence,
-    ) -> pub ([Field; 2], BoundedVec<u8, MAX_EMAIL_ADDRESS_LENGTH>, BoundedVec<u8, MAX_EMAIL_ADDRESS_LENGTH>) {
+    ) -> pub ([Field; 3], BoundedVec<u8, MAX_EMAIL_ADDRESS_LENGTH>, BoundedVec<u8, MAX_EMAIL_ADDRESS_LENGTH>) {
     // check the body and header lengths are within bounds
     assert(header.len() <= MAX_EMAIL_HEADER_LENGTH);
 
@@ -45,6 +46,7 @@ fn main(
 
     // hash the pubkey and signature for the standard outputs
     let email_nullifier = pedersen_hash(signature);
-    let standard_out = [pubkey.hash(), email_nullifier];
+    let pubkey_hash = pubkey.hash();
+    let standard_out = [pubkey_hash[0], pubkey_hash[1], email_nullifier];
     (standard_out, from_address, to_address)
 }

--- a/examples/partial_hash/src/main.nr
+++ b/examples/partial_hash/src/main.nr
@@ -21,8 +21,9 @@ global MAX_PARTIAL_EMAIL_BODY_LENGTH: u32 = 192;
  * @param redc_params_limbs - Barrett Reduction Parameter for Pubkey for efficient signature verification
  * @param signature - The DKIM RSA Signature
  * @return - 
- *         0: Pedersen hash of DKIM public key (root of trust)
- *         1: Pedersen hash of DKIM signature (email nullifier)
+ *         0: Poseidon hash of DKIM public key modulus (root of trust)
+ *         1: Poseidon hash of DKIM public key redc parameter
+ *         2: Pedersen hash of DKIM signature (email nullifier)
  */
 fn main(
     header: BoundedVec<u8, MAX_EMAIL_HEADER_LENGTH>,
@@ -33,7 +34,7 @@ fn main(
     dkim_header_sequence: Sequence,
     partial_body_hash: [u32; 8],
     partial_body_real_length: u64,
-) -> pub [Field; 2] {
+) -> pub [Field; 3] {
     // check the body and header lengths are within bounds
     assert(header.len() <= MAX_EMAIL_HEADER_LENGTH, "Email header length exceeds maximum length");
     assert(
@@ -63,5 +64,6 @@ fn main(
 
     // hash the pubkey and signature for the standard outputs
     let email_nullifier = pedersen_hash(signature);
-    [pubkey.hash(), email_nullifier]
+    let pubkey_hash = pubkey.hash();
+    [pubkey_hash[0], pubkey_hash[1], email_nullifier]
 }

--- a/examples/remove_soft_line_breaks/src/main.nr
+++ b/examples/remove_soft_line_breaks/src/main.nr
@@ -19,8 +19,9 @@ global MAX_EMAIL_BODY_LENGTH: u32 = 1024;
  * @param body_hash_index - The index of the body hash in the partial hash array
  * @param dkim_header_sequence - The index and length of the DKIM header field
  * @return - 
- *         0: Pedersen hash of DKIM public key (root of trust)
- *         1: Pedersen hash of DKIM signature (email nullifier)
+ *         0: Poseidon hash of DKIM public key modulus (root of trust)
+ *         1: Poseidon hash of DKIM public key redc parameter
+ *         2: Pedersen hash of DKIM signature (email nullifier)
  */
 fn main(
     header: BoundedVec<u8, MAX_EMAIL_HEADER_LENGTH>,
@@ -30,7 +31,7 @@ fn main(
     signature: [Field; KEY_LIMBS_2048],
     body_hash_index: u32,
     dkim_header_sequence: Sequence,
-) -> pub [Field; 2] {
+) -> pub [Field; 3] {
     // check the body and header lengths are within bounds
     assert(header.len() <= MAX_EMAIL_HEADER_LENGTH);
     assert(body.len() <= MAX_EMAIL_BODY_LENGTH);
@@ -63,5 +64,6 @@ fn main(
     // ~ 10,255 constraints
     // hash the pubkey and signature for the standard outputs
     let email_nullifier = pedersen_hash(signature);
-    [pubkey.hash(), email_nullifier]
+    let pubkey_hash = pubkey.hash();
+    [pubkey_hash[0], pubkey_hash[1], email_nullifier]
 }

--- a/examples/verify_email_1024_bit_dkim/src/main.nr
+++ b/examples/verify_email_1024_bit_dkim/src/main.nr
@@ -15,9 +15,10 @@ global MAX_EMAIL_BODY_LENGTH: u32 = 1024;
  * @param signature - The DKIM RSA Signature
  * @param body_hash_index - The index of the body hash in the partial hash array
  * @param dkim_header_sequence - The index and length of the DKIM header field
- * @return - 
- *         0: Pedersen hash of DKIM public key (root of trust)
- *         1: Pedersen hash of DKIM signature (email nullifier)
+ * @return -
+ *         0: Poseidon hash of DKIM public key modulus (root of trust)
+ *         1: Poseidon hash of DKIM public key redc parameter
+ *         2: Pedersen hash of DKIM signature (email nullifier)
  */
 fn main(
     header: BoundedVec<u8, MAX_EMAIL_HEADER_LENGTH>,
@@ -26,7 +27,7 @@ fn main(
     signature: [Field; KEY_LIMBS_1024],
     body_hash_index: u32,
     dkim_header_sequence: Sequence,
-) -> pub [Field; 2] {
+) -> pub [Field; 3] {
     // check the body and header lengths are within bounds
     assert(header.len() <= MAX_EMAIL_HEADER_LENGTH);
     assert(body.len() <= MAX_EMAIL_BODY_LENGTH);
@@ -48,5 +49,6 @@ fn main(
 
     // hash the pubkey and signature for the standard outputs
     let email_nullifier = pedersen_hash(signature);
-    [pubkey.hash(), email_nullifier]
+    let pubkey_hash = pubkey.hash();
+    [pubkey_hash[0], pubkey_hash[1], email_nullifier]
 }

--- a/examples/verify_email_2048_bit_dkim/src/main.nr
+++ b/examples/verify_email_2048_bit_dkim/src/main.nr
@@ -16,8 +16,9 @@ global MAX_EMAIL_BODY_LENGTH: u32 = 1024;
  * @param body_hash_index - The index of the body hash in the partial hash array
  * @param dkim_header_sequence - The index and length of the DKIM header field
  * @return - 
- *         0: Pedersen hash of DKIM public key (root of trust)
- *         1: Pedersen hash of DKIM signature (email nullifier)
+ *         0: Poseidon hash of DKIM public key modulus (root of trust)
+ *         1: Poseidon hash of DKIM public key redc parameter
+ *         2: Pedersen hash of DKIM signature (email nullifier)
  */
 fn main(
     header: BoundedVec<u8, MAX_EMAIL_HEADER_LENGTH>,
@@ -26,7 +27,7 @@ fn main(
     signature: [Field; KEY_LIMBS_2048],
     body_hash_index: u32,
     dkim_header_sequence: Sequence,
-) -> pub [Field; 2] {
+) -> pub [Field; 3] {
     // check the body and header lengths are within bounds
     assert(header.len() <= MAX_EMAIL_HEADER_LENGTH);
     assert(body.len() <= MAX_EMAIL_BODY_LENGTH);
@@ -52,5 +53,6 @@ fn main(
     // ~ 10,255 constraints
     // hash the pubkey and signature for the standard outputs
     let email_nullifier = pedersen_hash(signature);
-    [pubkey.hash(), email_nullifier]
+    let pubkey_hash = pubkey.hash();
+    [pubkey_hash[0], pubkey_hash[1], email_nullifier]
 }

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zk-email/zkemail-nr",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "main": "dist",
   "types": "dist",
   "license": "MIT",

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -21,6 +21,7 @@ import {
 
 export { verifyDKIMSignature } from "@zk-email/helpers/dist/dkim";
 export { hashRSAPublicKey } from "./utils";
+export type { RSAPublicKeyHashes } from "./utils";
 
 // This file is essentially https://github.com/zkemail/zk-email-verify/blob/main/packages/helpers/src/input-generators.ts
 // modified for noir input generation

--- a/js/src/utils.ts
+++ b/js/src/utils.ts
@@ -146,47 +146,31 @@ export function makeEmailAddressCharTable(): string {
   return tableStr;
 }
 
-/**
- * Hash an RSA public key by converting 18 x 120-bit limbs into 17 x 121-bit chunks (modulus-only),
- * mirroring Noir RSAPubkey<2048>::hash.
- *
- * Process:
- * - Inputs are 18 limbs of 120 bits for the modulus and redc (redc unused in hashing).
- * - Build 17 contiguous 121-bit chunks from the 18 x 120-bit modulus limbs.
- * - Merge pairs of 121-bit chunks into 8 elements using base 2^121; keep the last chunk as the 9th element:
- *   input[i] = chunk[2i] + chunk[2i+1] * 2^121, for i in 0..7
- *   input[8] = chunk[16]
- * - Poseidon(input[0..8]) -> final hash
- *
- * @param modulusLimbs 18 BigInts (each <= 120 bits) representing the RSA modulus limbs
- * @param redcLimbs 18 BigInts (unused in hashing; kept for backward compatibility)
- * @returns Final Poseidon hash as a BigInt
- */
-export async function hashRSAPublicKey(
-  modulusLimbs: bigint[],
-  redcLimbs: bigint[]
-): Promise<bigint> {
+export type RSAPublicKeyHashes = {
+  modulusHash: bigint;
+  redcHash: bigint;
+};
+
+function hashLimbArrayToPoseidon(
+  limbs120: bigint[],
+  poseidon: Awaited<ReturnType<typeof buildPoseidon>>
+): bigint {
   const NUM_INPUT_LIMBS_120 = 18; // 18 x 120-bit limbs
   const NUM_CHUNKS_121 = 17; // produce 17 contiguous 121-bit chunks
   const NUM_POSEIDON_INPUTS = 9;
   const BASE_121 = 1n << 121n;
 
-  if (
-    modulusLimbs.length !== NUM_INPUT_LIMBS_120 ||
-    redcLimbs.length !== NUM_INPUT_LIMBS_120
-  ) {
+  if (limbs120.length !== NUM_INPUT_LIMBS_120) {
     throw new Error(
-      `Expected ${NUM_INPUT_LIMBS_120} limbs for both modulus and redc, but received ${modulusLimbs.length} and ${redcLimbs.length}`
+      `Expected ${NUM_INPUT_LIMBS_120} limbs, but received ${limbs120.length}`
     );
   }
-
-  const poseidon = await buildPoseidon();
 
   // Step 1: Build 17 contiguous 121-bit chunks from 18 x 120-bit limbs
   const chunks121: bigint[] = new Array(NUM_CHUNKS_121).fill(0n);
   for (let j = 0; j < NUM_CHUNKS_121; j++) {
-    const a0 = modulusLimbs[j];
-    const a1 = j + 1 < NUM_INPUT_LIMBS_120 ? modulusLimbs[j + 1] : 0n;
+    const a0 = limbs120[j];
+    const a1 = j + 1 < NUM_INPUT_LIMBS_120 ? limbs120[j + 1] : 0n;
 
     const shiftLow = BigInt(j);
     const lower = a0 >> shiftLow; // a0 / 2^j
@@ -209,7 +193,23 @@ export async function hashRSAPublicKey(
   poseidonInputs[8] = chunks121[16];
 
   const finalHashRaw = poseidon(poseidonInputs);
-  const finalHash = poseidon.F.toObject(finalHashRaw);
+  return poseidon.F.toObject(finalHashRaw);
+}
 
-  return finalHash;
+/**
+ * Hash RSA pubkey limbs into separate Poseidon hashes for modulus and redc.
+ *
+ * This mirrors the Noir limb-conversion and folding path used in
+ * RSAPubkey<2048>::hash-compatible hashing.
+ */
+export async function hashRSAPublicKey(
+  modulusLimbs: bigint[],
+  redcLimbs: bigint[]
+): Promise<RSAPublicKeyHashes> {
+  const poseidon = await buildPoseidon();
+
+  return {
+    modulusHash: hashLimbArrayToPoseidon(modulusLimbs, poseidon),
+    redcHash: hashLimbArrayToPoseidon(redcLimbs, poseidon),
+  };
 }

--- a/js/src/utils.ts
+++ b/js/src/utils.ts
@@ -156,21 +156,27 @@ function hashLimbArrayToPoseidon(
   poseidon: Awaited<ReturnType<typeof buildPoseidon>>
 ): bigint {
   const NUM_INPUT_LIMBS_120 = 18; // 18 x 120-bit limbs
+  const NUM_LIMBS_1024 = 9; // 9 x 120-bit limbs for 1024-bit keys
   const NUM_CHUNKS_121 = 17; // produce 17 contiguous 121-bit chunks
   const NUM_POSEIDON_INPUTS = 9;
   const BASE_121 = 1n << 121n;
 
-  if (limbs120.length !== NUM_INPUT_LIMBS_120) {
+  if (limbs120.length !== NUM_INPUT_LIMBS_120 && limbs120.length !== NUM_LIMBS_1024) {
     throw new Error(
-      `Expected ${NUM_INPUT_LIMBS_120} limbs, but received ${limbs120.length}`
+      `Expected ${NUM_INPUT_LIMBS_120} or ${NUM_LIMBS_1024} limbs, but received ${limbs120.length}`
     );
   }
+
+  // Pad 1024-bit (9 limbs) to 2048-bit width (18 limbs) — mirrors Noir's poseidon_large_padded_1024
+  const padded = limbs120.length === NUM_INPUT_LIMBS_120
+    ? limbs120
+    : [...limbs120, ...new Array(NUM_INPUT_LIMBS_120 - limbs120.length).fill(0n)];
 
   // Step 1: Build 17 contiguous 121-bit chunks from 18 x 120-bit limbs
   const chunks121: bigint[] = new Array(NUM_CHUNKS_121).fill(0n);
   for (let j = 0; j < NUM_CHUNKS_121; j++) {
-    const a0 = limbs120[j];
-    const a1 = j + 1 < NUM_INPUT_LIMBS_120 ? limbs120[j + 1] : 0n;
+    const a0 = padded[j];
+    const a1 = j + 1 < NUM_INPUT_LIMBS_120 ? padded[j + 1] : 0n;
 
     const shiftLow = BigInt(j);
     const lower = a0 >> shiftLow; // a0 / 2^j

--- a/js/tests/circuits.test.ts
+++ b/js/tests/circuits.test.ts
@@ -164,10 +164,14 @@ describe("ZKEmail.nr Circuit Unit Tests", () => {
       );
       let modulus = inputs.pubkey.modulus.map((limb) => BigInt(limb));
       let redc = inputs.pubkey.redc.map((limb) => BigInt(limb));
-      let computed_hash = await hashRSAPublicKey(modulus, redc);
+      let computedHashes = await hashRSAPublicKey(modulus, redc);
       const result = await prover2048.simulateWitness(inputs);
+      // returnValue[0] = modulus hash, returnValue[1] = redc hash, returnValue[2] = email nullifier
       expect(result.returnValue[0].slice(2)).toEqual(
-        computed_hash.toString(16)
+        computedHashes.modulusHash.toString(16)
+      );
+      expect(result.returnValue[1].slice(2)).toEqual(
+        computedHashes.redcHash.toString(16)
       );
     });
   });

--- a/js/tests/circuits.test.ts
+++ b/js/tests/circuits.test.ts
@@ -176,3 +176,58 @@ describe("ZKEmail.nr Circuit Unit Tests", () => {
     });
   });
 });
+
+describe("hashRSAPublicKey 1024-bit parity", () => {
+  it("1024-bit (9-limb) hash matches zero-padded 2048-bit (18-limb) hash", async () => {
+    // Synthetic 1024-bit key: 9 limbs for modulus and redc
+    const modulus9 = [
+      0xaabbccdd11223344aabbccdd1122n,
+      0x112233445566778899aabbccddeen,
+      0xffeeddccbbaa99887766554433n,
+      0x00112233445566778899aabbccddeen,
+      0xdeadbeefcafebabe12345678abcdn,
+      0xfedcba98765432100fedcba98765n,
+      0x0123456789abcdef0123456789abn,
+      0xabcdef0123456789abcdef012345n,
+      0xdeadbeefcafebaben,
+    ];
+    const redc9 = [
+      0x111111111111111111111111111111n,
+      0x222222222222222222222222222222n,
+      0x333333333333333333333333333333n,
+      0x444444444444444444444444444444n,
+      0x555555555555555555555555555555n,
+      0x666666666666666666666666666666n,
+      0x777777777777777777777777777777n,
+      0x888888888888888888888888888888n,
+      0x99999999999999999999n,
+    ];
+
+    // Hash with 9 limbs (1024-bit path)
+    const hash1024 = await hashRSAPublicKey(modulus9, redc9);
+
+    // Same data, manually zero-padded to 18 limbs (2048-bit path)
+    const modulus18 = [...modulus9, ...new Array(9).fill(0n)];
+    const redc18 = [...redc9, ...new Array(9).fill(0n)];
+    const hash2048Padded = await hashRSAPublicKey(modulus18, redc18);
+
+    // Both paths must produce identical hashes — this validates the JS padding
+    // logic mirrors Noir's poseidon_large_padded_1024
+    expect(hash1024.modulusHash).toEqual(hash2048Padded.modulusHash);
+    expect(hash1024.redcHash).toEqual(hash2048Padded.redcHash);
+  });
+
+  it("1024-bit hash changes when redc is modified", async () => {
+    const modulus = [1n, 2n, 3n, 4n, 5n, 6n, 7n, 8n, 9n];
+    const redc = [10n, 20n, 30n, 40n, 50n, 60n, 70n, 80n, 90n];
+    const tamperedRedc = [11n, 20n, 30n, 40n, 50n, 60n, 70n, 80n, 90n]; // redc[0] changed
+
+    const original = await hashRSAPublicKey(modulus, redc);
+    const tampered = await hashRSAPublicKey(modulus, tamperedRedc);
+
+    // modulus hash unchanged (same modulus)
+    expect(original.modulusHash).toEqual(tampered.modulusHash);
+    // redc hash changed
+    expect(original.redcHash).not.toEqual(tampered.redcHash);
+  });
+});

--- a/lib/src/dkim.nr
+++ b/lib/src/dkim.nr
@@ -1,4 +1,4 @@
-use crate::{hash::poseidon_large, KEY_LIMBS_1024, KEY_LIMBS_2048, RSA_EXPONENT};
+use crate::{hash::{poseidon_large, poseidon_large_padded_1024}, KEY_LIMBS_1024, KEY_LIMBS_2048, RSA_EXPONENT};
 use bignum::{params::BigNumParams, RuntimeBigNum};
 use poseidon::poseidon;
 use rsa::{rsa::verify_sha256_pkcs1v15, types::{RBN1024, RBN2048}};
@@ -42,22 +42,10 @@ impl RSAPubkey<KEY_LIMBS_1024> {
         header_hash
     }
 
-    pub fn hash(self) -> Field {
+    pub fn hash(self) -> [Field; 2] {
         // validate
         self.validate_in_range();
-        let mut dkim_preimage = [0; 9];
-        // compose first 4 limbs of modulus and redc
-        for i in 0..4 {
-            let modulus_hi = self.modulus[i * 2] * 2.pow_32(120);
-            let redc_hi = self.redc[i * 2] * 2.pow_32(120);
-            dkim_preimage[i] = modulus_hi + self.modulus[i * 2 + 1];
-            dkim_preimage[i + 4] = redc_hi + self.redc[i * 2 + 1];
-        }
-        // compose last two elements of redc and modulus together
-        let modulus_hi = self.modulus[8] * 2.pow_32(120);
-        dkim_preimage[8] = modulus_hi + self.redc[8];
-        // hash the pubkey
-        poseidon::bn254::hash_9(dkim_preimage)
+        [poseidon_large_padded_1024(self.modulus), poseidon_large_padded_1024(self.redc)]
     }
 
     pub fn validate_in_range(self) {

--- a/lib/src/dkim.nr
+++ b/lib/src/dkim.nr
@@ -95,10 +95,10 @@ impl RSAPubkey<KEY_LIMBS_2048> {
         header_hash
     }
 
-    pub fn hash(self) -> Field {
+    pub fn hash(self) -> [Field; 2] {
         // validate range
         self.validate_in_range();
-        poseidon_large(self.modulus)
+        [poseidon_large(self.modulus), poseidon_large(self.redc)]
     }
 
     pub fn validate_in_range(self) {

--- a/lib/src/dkim.nr
+++ b/lib/src/dkim.nr
@@ -1,4 +1,9 @@
-use crate::{hash::{poseidon_large, poseidon_large_padded_1024}, KEY_LIMBS_1024, KEY_LIMBS_2048, RSA_EXPONENT};
+use crate::{
+    hash::{poseidon_large, poseidon_large_padded_1024},
+    KEY_LIMBS_1024,
+    KEY_LIMBS_2048,
+    RSA_EXPONENT,
+};
 use bignum::{params::BigNumParams, RuntimeBigNum};
 use rsa::{rsa::verify_sha256_pkcs1v15, types::{RBN1024, RBN2048}};
 use sha256::sha256_var;

--- a/lib/src/dkim.nr
+++ b/lib/src/dkim.nr
@@ -1,6 +1,5 @@
 use crate::{hash::{poseidon_large, poseidon_large_padded_1024}, KEY_LIMBS_1024, KEY_LIMBS_2048, RSA_EXPONENT};
 use bignum::{params::BigNumParams, RuntimeBigNum};
-use poseidon::poseidon;
 use rsa::{rsa::verify_sha256_pkcs1v15, types::{RBN1024, RBN2048}};
 use sha256::sha256_var;
 

--- a/lib/src/hash.nr
+++ b/lib/src/hash.nr
@@ -1,4 +1,4 @@
-use crate::KEY_LIMBS_2048;
+use crate::{KEY_LIMBS_1024, KEY_LIMBS_2048};
 use poseidon::poseidon;
 
 // Hash 18 x 120-bit limbs into a single Field - compatible with https://github.com/zkemail/zk-email-verify/blob/62dd54871857697a6f2fb9c0a8ea72e38c7eb293/packages/circuits/utils/hash.circom#L15
@@ -60,4 +60,18 @@ pub fn fold_limbs121<let K: u32, let K_out: u32>(limbs121: [Field; K]) -> [Field
         }
     }
     input
+}
+
+// Pad 1024-bit limbs (9 x 120-bit) to 2048-bit width (18 x 120-bit) by appending zero limbs.
+pub fn pad_limbs_1024_to_2048(limbs120x9: [Field; KEY_LIMBS_1024]) -> [Field; KEY_LIMBS_2048] {
+    let mut padded: [Field; KEY_LIMBS_2048] = [0; KEY_LIMBS_2048];
+    for i in 0..KEY_LIMBS_1024 {
+        padded[i] = limbs120x9[i];
+    }
+    padded
+}
+
+// Hash a 1024-bit key array by zero-padding to 2048-bit width and reusing poseidon_large.
+pub fn poseidon_large_padded_1024(limbs120x9: [Field; KEY_LIMBS_1024]) -> Field {
+    poseidon_large(pad_limbs_1024_to_2048(limbs120x9))
 }

--- a/lib/src/tests/mod.nr
+++ b/lib/src/tests/mod.nr
@@ -129,14 +129,13 @@ mod test_tampered_hash {
     }
 }
 
-mod test_redc_binding {
+mod test_redc_binding_2048 {
     use crate::tests::test_inputs::EmailLarge;
 
     /// Regression test for Veridise vulnerability reintroduced by PR #52.
-    /// Verifies that modifying redc changes the hash output, i.e. the prover
-    /// is bound to the redc parameter they provide.
+    /// Verifies that modifying redc changes hash[1] (redc hash) but NOT hash[0] (modulus hash).
     #[test]
-    fn test_modified_redc_changes_hash() {
+    fn test_modified_redc_changes_hash_2048() {
         let pubkey = EmailLarge::PUBKEY;
         let original_hash = pubkey.hash();
 
@@ -146,11 +145,43 @@ mod test_redc_binding {
         let tampered_pubkey = crate::dkim::RSAPubkey::new(pubkey.modulus, tampered_redc);
         let tampered_hash = tampered_pubkey.hash();
 
-        // The hash MUST differ when redc is modified -- if it doesn't,
-        // an attacker could substitute a different redc and forge proofs
+        // hash[0] = poseidon(modulus) -- must be UNCHANGED since modulus is the same
         assert(
-            original_hash != tampered_hash,
-            "hash() must produce different output when redc is modified",
+            original_hash[0] == tampered_hash[0],
+            "modulus hash (hash[0]) must not change when only redc is modified",
+        );
+        // hash[1] = poseidon(redc) -- must DIFFER since redc was tampered
+        assert(
+            original_hash[1] != tampered_hash[1],
+            "redc hash (hash[1]) must change when redc is modified",
+        );
+    }
+}
+
+mod test_redc_binding_1024 {
+    use crate::tests::test_inputs::EmailSmall;
+
+    /// Same regression test as test_redc_binding but for the 1024-bit code path,
+    /// which uses poseidon_large_padded_1024 (pads 9 limbs to 18 before hashing).
+    #[test]
+    fn test_modified_redc_changes_hash_1024() {
+        let pubkey = EmailSmall::PUBKEY;
+        let original_hash = pubkey.hash();
+
+        let mut tampered_redc = pubkey.redc;
+        tampered_redc[0] = tampered_redc[0] + 1;
+        let tampered_pubkey = crate::dkim::RSAPubkey::new(pubkey.modulus, tampered_redc);
+        let tampered_hash = tampered_pubkey.hash();
+
+        // hash[0] = poseidon_large_padded_1024(modulus) -- must be UNCHANGED
+        assert(
+            original_hash[0] == tampered_hash[0],
+            "modulus hash (hash[0]) must not change when only redc is modified (1024-bit)",
+        );
+        // hash[1] = poseidon_large_padded_1024(redc) -- must DIFFER
+        assert(
+            original_hash[1] != tampered_hash[1],
+            "redc hash (hash[1]) must change when redc is modified (1024-bit)",
         );
     }
 }

--- a/lib/src/tests/mod.nr
+++ b/lib/src/tests/mod.nr
@@ -129,6 +129,32 @@ mod test_tampered_hash {
     }
 }
 
+mod test_redc_binding {
+    use crate::tests::test_inputs::EmailLarge;
+
+    /// Regression test for Veridise vulnerability reintroduced by PR #52.
+    /// Verifies that modifying redc changes the hash output, i.e. the prover
+    /// is bound to the redc parameter they provide.
+    #[test]
+    fn test_modified_redc_changes_hash() {
+        let pubkey = EmailLarge::PUBKEY;
+        let original_hash = pubkey.hash();
+
+        // Construct a pubkey with same modulus but tampered redc (flip one limb)
+        let mut tampered_redc = pubkey.redc;
+        tampered_redc[0] = tampered_redc[0] + 1;
+        let tampered_pubkey = crate::dkim::RSAPubkey::new(pubkey.modulus, tampered_redc);
+        let tampered_hash = tampered_pubkey.hash();
+
+        // The hash MUST differ when redc is modified -- if it doesn't,
+        // an attacker could substitute a different redc and forge proofs
+        assert(
+            original_hash != tampered_hash,
+            "hash() must produce different output when redc is modified",
+        );
+    }
+}
+
 mod header_field_access {
 
     use crate::{headers::body_hash::get_body_hash, Sequence, tests::test_inputs::EmailLarge};

--- a/lib/src/tests/test_inputs.nr
+++ b/lib/src/tests/test_inputs.nr
@@ -243,6 +243,40 @@ pub(crate) mod EmailAddressUnderscore {
     pub(crate) global ADDRESS_SEQUENCE: Sequence = Sequence { index: 7, length: 20 };
 }
 
+pub(crate) mod EmailSmall {
+    use crate::{dkim::RSAPubkey, KEY_LIMBS_1024};
+
+    // Synthetic 1024-bit RSA key for hash testing.
+    // Values are arbitrary but respect range constraints:
+    // - modulus limbs[0..7]: 120 bits each
+    // - modulus limbs[8]: 64 bits (1024 - 8*120 = 64)
+    // - redc limbs[0..8]: 120 bits each
+    pub(crate) global PUBKEY: RSAPubkey<KEY_LIMBS_1024> = RSAPubkey::new(
+        [
+            0xaabbccdd11223344aabbccdd1122,
+            0x112233445566778899aabbccddee,
+            0xffeeddccbbaa99887766554433,
+            0x00112233445566778899aabbccddee,
+            0xdeadbeefcafebabe12345678abcd,
+            0xfedcba98765432100fedcba98765,
+            0x0123456789abcdef0123456789ab,
+            0xabcdef0123456789abcdef012345,
+            0xdeadbeefcafebabe,
+        ],
+        [
+            0x111111111111111111111111111111,
+            0x222222222222222222222222222222,
+            0x333333333333333333333333333333,
+            0x444444444444444444444444444444,
+            0x555555555555555555555555555555,
+            0x666666666666666666666666666666,
+            0x777777777777777777777777777777,
+            0x888888888888888888888888888888,
+            0x99999999999999999999,
+        ],
+    );
+}
+
 pub(crate) mod PartialHash {
     pub(crate) global DATA: [u8; 192] = [
         0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,


### PR DESCRIPTION
## Summary

Previously, `RSAPubkey::hash()` only committed to the modulus — meaning a malicious prover could supply an arbitrary `redc` parameter and still produce a valid proof against the same public key hash. This re-introduces the vulnerability identified by Veridise that was reintroduced in PR #52 when the hash was changed from Pedersen (which hashed modulus+redc together) to Poseidon (which only hashed the modulus).

This PR fixes the issue by having `hash()` return `[Field; 2]` — separate Poseidon hashes for both modulus and redc — so that the prover is bound to the exact reduction parameter used during verification.

## Changes

**Noir (`lib/`)**
- `RSAPubkey<2048>::hash()` now returns `[Field; 2]` — `[poseidon(modulus), poseidon(redc)]`
- `RSAPubkey<1024>::hash()` now returns `[Field; 2]` using a new `poseidon_large_padded_1024` helper that zero-pads 9 limbs to 18 before hashing
- Added `pad_limbs_1024_to_2048` and `poseidon_large_padded_1024` in `hash.nr`
- Removed the old 1024-bit hash path that interleaved modulus+redc into a single Poseidon preimage
- Added regression tests (`test_redc_binding_2048`, `test_redc_binding_1024`) that verify modifying redc changes `hash[1]` but not `hash[0]`

**JS (`js/`)**
- `hashRSAPublicKey()` now returns `{ modulusHash, redcHash }` (type `RSAPublicKeyHashes`)
- Extracted `hashLimbArrayToPoseidon()` to hash either limb array independently
- Added support for 1024-bit keys (9 limbs) with zero-padding to 18 limbs, mirroring Noir's `poseidon_large_padded_1024`
- Exported `RSAPublicKeyHashes` type from package entry point
- Added JS tests for 1024-bit parity (9-limb vs zero-padded 18-limb) and redc tamper detection

**Examples**
- All 6 example circuits updated: output changes from `[Field; 2]` to `[Field; 3]` (`[modulus_hash, redc_hash, email_nullifier]`)
- Documentation comments updated to reflect the new output format

## Breaking Changes

- `RSAPubkey::hash()` return type changes from `Field` to `[Field; 2]`
- `hashRSAPublicKey()` return type changes from `Promise<bigint>` to `Promise<RSAPublicKeyHashes>`
- Example circuit public outputs grow from 2 fields to 3 fields

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Circuit public outputs now return 3 fields instead of 2.
  * JavaScript API changed: `hashRSAPublicKey()` now returns `{ modulusHash, redcHash }` object instead of a single value.
  * Verifier keys must be regenerated.

* **Bug Fixes**
  * Fixed security vulnerability: prover now properly bound to the reduction parameter.

* **New Features**
  * Added support for 1024-bit RSA keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->